### PR TITLE
extract-text plugin fix

### DIFF
--- a/libs/webpack.tools.js
+++ b/libs/webpack.tools.js
@@ -33,7 +33,7 @@ exports.extractCSS = function(paths) {
       loaders: [
         {
           test: /\.scss$/,
-          loader: isDev ? 'style!css!sass' : ExtractTextPlugin.extract('style', 'css', 'sass'),
+          loader: isDev ? 'style!css!sass' : ExtractTextPlugin.extract('style', 'css!sass'),
           include: paths
         }
       ]


### PR DESCRIPTION
Extract text plugin configuration was busted. Changed it to use `css!sass` loader instead